### PR TITLE
Fix for Dockerfile regarding running on ARM platform

### DIFF
--- a/stalkerlab/Dockerfile
+++ b/stalkerlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM --platform=linux/amd64 python:3.11-slim
 
 # Install Chrome and Chrome WebDriver dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Minor fix in Dockerfile to make it possible to run application ARM platforms (for example, Apple Macbook Pros with M chips)

The main problem is caused by the package google-chrome-stable, which is not available for ARM platforms